### PR TITLE
Re-enable the use of the naming setting

### DIFF
--- a/src/plugin.scala
+++ b/src/plugin.scala
@@ -98,7 +98,7 @@ object AngularTemplates extends AutoPlugin {
         val namer = naming.value
 
         val tpls = maps.map { case (f, n) =>
-          (n, proc(IO.read(f)))
+          (namer(n), proc(IO.read(f)))
         }
 
         val outs = outputHtml.value.map { o =>


### PR DESCRIPTION
Commit d8070e08b191acc78c1a27639cc0f748d9b68406 removed the call to
"namer" when creating the templates name, content map.
